### PR TITLE
sepolicy: Define iso9660 fs type

### DIFF
--- a/mediatek/sepolicy_vndr/basic/non_plat/file.te
+++ b/mediatek/sepolicy_vndr/basic/non_plat/file.te
@@ -1,0 +1,1 @@
+type iso9660, fs_type;


### PR DESCRIPTION
- Added missing 'type iso9660, fs_type;' required by vold.te
- Fixes build error in MediaTek SEPolicy